### PR TITLE
simplecovでテストカバレッジを測定する

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,3 +31,7 @@ jobs:
       run: bundle install
     - name: Run tests
       run: bundle exec rake test
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Test Coverage
+        path: coverage

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'minitest'
 gem 'rake'
+gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    docile (1.3.2)
     minitest (5.14.2)
     rake (13.0.1)
+    simplecov (0.19.1)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
 
 PLATFORMS
   ruby
@@ -10,6 +15,7 @@ PLATFORMS
 DEPENDENCIES
   minitest
   rake
+  simplecov
 
 BUNDLED WITH
    2.1.4

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path('../src', __dir__)
 Dir["./src/*.rb"].each {|file| require file }
 


### PR DESCRIPTION
simplecov gemを導入して、自動テスト実行時にテストカバレッジが測定されるようにしました。

- 自動テストを実行すると`./coverage/index.html`が生成され、カバレッジを確認できます。
- GitHub Actionsでテスト実行後に`./coverage`をartifactとしてアップロードします。
